### PR TITLE
improve node constructor method

### DIFF
--- a/c++/src/linked-list.cc
+++ b/c++/src/linked-list.cc
@@ -12,22 +12,12 @@ private:
 
 public:
   //constructors
-  Node(T value) {
-    this->value = value;
-    this->next = nullptr;
-  }
+  Node(T value) : value(value), next(nullptr) {}
 
-  Node(T value, Node *next) {
-    this->value = value;
-    this->next = next;
-  }
+  Node(T value, Node *next) : value(value), next(next) {}
 
   // destructor
-  ~Node() {
-    // if (this->next) {
-    //   delete this->next;
-    // }
-  }
+  ~Node() {}
 
   // getters
   T getValue() {


### PR DESCRIPTION
@blaenk constructors in Node class now use ':' as opposed to setting values in the constructor body (ie this->value = value).
