### PR TITLE
add method to multiply capacity

### DIFF
--- a/c++/src/vector.cc
+++ b/c++/src/vector.cc
@@ -66,6 +66,7 @@ public:
     stream << "]";
   }
 
+private:
   void grow(int growFactor = 2) {
     this->capacity_ = this->capacity_ * growFactor;
     T *temp = this->dataStore_;
@@ -98,11 +99,16 @@ void test_empty_push() {
   test_expected_values(push_vector_empty, "[1]");
 }
 
-void test_full_push_throws_exception() {
+void test_full_push_doubles_capacity() {
   Vector<int> push_vector_full{1, 2, 3, 4, 5, 6, 7, 8};
   assert(push_vector_full.capacity() == push_vector_full.length());
 
-  test_throws_exception([&] {push_vector_full.push(9); });
+  unsigned int previousCapacity = push_vector_full.capacity();
+
+  push_vector_full.push(9);
+
+  assert(push_vector_full.capacity() == previousCapacity * 2);
+  test_expected_values(push_vector_full, "[1, 2, 3, 4, 5, 6, 7, 8, 9]");
 }
 
 void test_normal_pop() {
@@ -120,7 +126,7 @@ int main() {
   // test push
   test_normal_push();
   test_empty_push();
-  test_full_push_throws_exception();
+  test_full_push_doubles_capacity();
 
   // test pop
   test_normal_pop();

--- a/c++/src/vector.cc
+++ b/c++/src/vector.cc
@@ -29,7 +29,7 @@ public:
 
   void push(T val) {
     if (this->length_ >= capacity_) {
-      throw std::out_of_range("Vector capacity exceeded.");
+      this->grow();
     }
 
     this->dataStore_[this->length_] = val;

--- a/c++/src/vector.cc
+++ b/c++/src/vector.cc
@@ -65,6 +65,19 @@ public:
 
     stream << "]";
   }
+
+  void grow(int growFactor = 2) {
+    this->capacity_ = this->capacity_ * growFactor;
+    T *temp = this->dataStore_;
+
+    this->dataStore_ = new T[this->capacity_];
+
+    for (unsigned int i = 0; i < this->length_; i++) {
+      this->dataStore_[i] = temp[i];
+    }
+
+    delete[] temp;
+  }
 };
 
 


### PR DESCRIPTION
@blaenk added a method that can double the capacity of the vector: create a pointer to the member array, reassign the member array to a new array of double the capacity, and insert the data from the previous array into the new one.
